### PR TITLE
Migrate to Version Catalog and update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,21 +24,21 @@ repositories {
 
 dependencies {
 	// jUnit 5
-    implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+    implementation libs.junit.jupyter
 
 	// Spring DI
-	implementation 'org.springframework:spring-context:5.3.13'
+	implementation libs.spring.di
 
 	// To change the versions see the gradle.properties file
-	minecraft "com.mojang:minecraft:${project.minecraft_version}"
-	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
-	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
+	minecraft libs.minecraft
+	mappings variantOf(libs.fabric.yarn) { classifier("v2") }
+	modImplementation libs.fabric.loader
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	modImplementation libs.fabric.api
 
 	// Worldedit API
-	modImplementation "com.sk89q.worldedit:worldedit-fabric-mc1.18.2:7.2.10"
+	modImplementation libs.worldedit
 }
 
 processResources {
@@ -63,7 +63,7 @@ java {
 
 jar {
 	from("LICENSE") {
-		rename { "${it}_${project.archivesBaseName}"}
+		rename { "${it}_${project.archives_base_name}"}
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,7 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx1G
 
-# Fabric Properties
-	# check these on https://fabricmc.net/develop
-	minecraft_version=1.18.2
-	yarn_mappings=1.18.2+build.3
-	loader_version=0.14.6
-
 # Mod Properties
 	mod_version = 1.0.0
-	maven_group = com.example
-	archives_base_name = fabric-example-mod
-
-# Dependencies
-	fabric_version=0.53.0+1.18.2
+	maven_group = com.domain
+	archives_base_name = redstonetools

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,25 @@
+[versions]
+minecraft = "1.18.2"
+yarn-mappings = "1.18.2+build.4"
+loader = "0.14.14"
+
+fabric = "0.48.0+1.18.2"
+worldedit = "7.2.10"
+
+junit = "5.8.1"
+spring-di = "5.3.19"
+
+[libraries]
+# Fabric Properties
+# check these on https://fabricmc.net/develop
+minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
+fabric-yarn = { module = "net.fabricmc:yarn", version.ref = "yarn-mappings" }
+fabric-loader = { module = "net.fabricmc:fabric-loader", version.ref = "loader" }
+
+# Mod dependencies
+fabric-api = { module = "net.fabricmc.fabric-api:fabric-api", version.ref = "fabric" }
+worldedit = { module = "com.sk89q.worldedit:worldedit-fabric-mc1.18.2", version.ref = "worldedit" }
+
+# Other dependencies
+junit-jupyter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+spring-di = { module = "org.springframework:spring-context", version.ref = "spring-di" }


### PR DESCRIPTION
Version Catalog can make managing dependencies and their versions easily and make build.gradle more readable.
Also changed the domain name.