### PR TITLE
Removed code duplication

### DIFF
--- a/src/main/java/com/domain/redstonetools/features/commands/PickBlockFeature.java
+++ b/src/main/java/com/domain/redstonetools/features/commands/PickBlockFeature.java
@@ -1,0 +1,42 @@
+package com.domain.redstonetools.features.commands;
+
+import com.domain.redstonetools.features.options.Options;
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+
+public abstract class PickBlockFeature<O extends Options> extends RayCastFeature<O> {
+
+
+    @Override
+    protected int execute(ServerCommandSource source, Options options, BlockHitResult blockHit) throws CommandSyntaxException {
+        MinecraftClient client = MinecraftClient.getInstance();
+        ItemStack stack = getItemStack(source, options, blockHit);
+
+        if (stack == null) {//sending error message should be handled by extending class
+            return -1;
+        }
+
+        PlayerInventory playerInventory = client.player.getInventory();
+        playerInventory.addPickBlock(stack);
+
+        if (client.interactionManager == null) {
+            throw new CommandSyntaxException(null, Text.of("Failed to get interaction manager"));
+        }
+
+        client.interactionManager.clickCreativeStack(client.player.getStackInHand(Hand.MAIN_HAND), 36 + playerInventory.selectedSlot);
+
+        return Command.SINGLE_SUCCESS;
+    }
+
+
+    protected abstract ItemStack getItemStack(ServerCommandSource source, Options options, BlockHitResult blockHit) throws CommandSyntaxException;
+
+
+}

--- a/src/main/java/com/domain/redstonetools/features/commands/RayCastFeature.java
+++ b/src/main/java/com/domain/redstonetools/features/commands/RayCastFeature.java
@@ -1,0 +1,33 @@
+package com.domain.redstonetools.features.commands;
+
+import com.domain.redstonetools.features.options.Options;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.Text;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.hit.HitResult;
+
+public abstract class RayCastFeature<O extends Options> extends CommandFeature<O>{
+
+
+    protected int execute(ServerCommandSource source, Options options) throws CommandSyntaxException {
+        MinecraftClient client = MinecraftClient.getInstance();
+        if (client.player == null || client.world == null) {
+            throw new CommandSyntaxException(null, Text.of("This command is client-side only"));
+        }
+
+        if (client.crosshairTarget == null || client.crosshairTarget.getType() != HitResult.Type.BLOCK) {
+            source.sendError(Text.of("You must be looking at a block to use this command"));
+
+            return -1;
+        }
+
+
+        return execute(source, options,(BlockHitResult) client.crosshairTarget);
+    }
+
+    protected abstract int execute(ServerCommandSource source, Options options,BlockHitResult blockHit) throws CommandSyntaxException;
+
+
+}

--- a/src/main/java/com/domain/redstonetools/features/commands/glass/GlassFeature.java
+++ b/src/main/java/com/domain/redstonetools/features/commands/glass/GlassFeature.java
@@ -1,63 +1,29 @@
 package com.domain.redstonetools.features.commands.glass;
 
 import com.domain.redstonetools.features.Feature;
-import com.domain.redstonetools.features.commands.CommandFeature;
+import com.domain.redstonetools.features.commands.PickBlockFeature;
 import com.domain.redstonetools.features.options.EmptyOptions;
+import com.domain.redstonetools.features.options.Options;
 import com.domain.redstonetools.utils.ItemUtils;
-import com.mojang.brigadier.Command;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.Text;
-import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
-import net.minecraft.util.hit.HitResult;
 import net.minecraft.util.registry.Registry;
 
 
 @Feature(name = "glass")
-public class GlassFeature extends CommandFeature<EmptyOptions> {
-    //similar to: net.minecraft.client.MinecraftClient/doItemPick()
+public class GlassFeature extends PickBlockFeature<EmptyOptions> {
+
     @Override
-    protected int execute(ServerCommandSource source, EmptyOptions options) throws CommandSyntaxException {
-        MinecraftClient client = MinecraftClient.getInstance();
-        if (client.player == null || client.world == null) {
-            throw new CommandSyntaxException(null, Text.of("This command is client-side only"));
-        }
+    protected ItemStack getItemStack(ServerCommandSource source, Options options, BlockHitResult blockHit) throws CommandSyntaxException {
+        ItemStack stack = getWoolOrGlassStackFromBlock(source.getPlayer().world.getBlockState(blockHit.getBlockPos()).getBlock());
+        if (stack == null) source.sendError(Text.of("Invalid block! Use on wool or glass"));
 
-        if (client.crosshairTarget == null || client.crosshairTarget.getType() != HitResult.Type.BLOCK) {
-            source.sendError(Text.of("You must be looking at a block to use this command"));
-
-            return -1;
-        }
-
-        BlockHitResult blockHit = (BlockHitResult) client.crosshairTarget;
-        BlockState blockState = client.world.getBlockState(blockHit.getBlockPos());
-
-        Block block = blockState.getBlock();
-        ItemStack itemStack = getWoolOrGlassStackFromBlock(block);
-
-        if (itemStack == null) {
-            source.sendError(Text.of("Invalid block! Use on wool or glass"));
-
-            return -1;
-        }
-
-        PlayerInventory playerInventory = client.player.getInventory();
-        playerInventory.addPickBlock(itemStack);
-
-        if (client.interactionManager == null) {
-            throw new CommandSyntaxException(null, Text.of("Failed to get interaction manager"));
-        }
-
-        client.interactionManager.clickCreativeStack(client.player.getStackInHand(Hand.MAIN_HAND), 36 + playerInventory.selectedSlot);
-
-        return Command.SINGLE_SUCCESS;
+        return stack;
     }
 
     private ItemStack getWoolOrGlassStackFromBlock(Block block) {
@@ -83,4 +49,5 @@ public class GlassFeature extends CommandFeature<EmptyOptions> {
 
         return null;
     }
+
 }

--- a/src/main/java/com/domain/redstonetools/utils/BlockStateNbtUtil.java
+++ b/src/main/java/com/domain/redstonetools/utils/BlockStateNbtUtil.java
@@ -18,6 +18,7 @@ public class BlockStateNbtUtil {
         for (Property<?> property : blockState.getEntries().keySet()) {
             valueMap.put(property.getName(), blockState.getEntries().get(property));
         }
+        if (valueMap.isEmpty()) return null;
 
         return valueMap.toString();
     }


### PR DESCRIPTION
Removed code duplication - #63 

I also came over a bug, where the game would crash when block copied with `/copystate` doesnt have any blockstates, so I fixed it by disallowing users to copy blocks without any states